### PR TITLE
Alternative container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,8 @@
-FROM registry.fedoraproject.org/fedora:41
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:latest
+
+FROM ${BASE_IMAGE}
 RUN dnf install -y python3 python3-pip python3-dnf skopeo rpm
 WORKDIR /app
-COPY . .
-RUN python3 -m pip install .
+ARG GIT_REF=heads/main
+RUN python3 -m pip install https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/${GIT_REF}.tar.gz
 ENTRYPOINT ["/usr/local/bin/rpm-lockfile-prototype"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ from a local container image using the [`Containerfile`](./Containerfile) at the
    $ podman build -f Containerfile -t localhost/rpm-lockfile-prototype
    ```
 
+   or, to skip cloning the repo and install the latest commit from `main`:
+
+   ```bash
+   $ curl https://raw.githubusercontent.com/konflux-ci/rpm-lockfile-prototype/refs/heads/main/Containerfile \
+      | podman build -t localhost/rpm-lockfile-prototype -
+   ```
+
+   Alternatively, to use a different base image that has `dnf` or specify a tag other than `main` 
+   to install:
+
+   ```bash
+   $ curl https://raw.githubusercontent.com/konflux-ci/rpm-lockfile-prototype/refs/heads/main/Containerfile \
+      | podman build -t localhost/rpm-lockfile-prototype \
+        --build-arg BASE_IMAGE=other-base-image:latest \
+        --build-arg GIT_REF=tags/v0.13.1 -
+   ```
 
 2. Run the image from the directory containing the `rpms.in.yaml` to generate the `rpms.lock.yaml`
    file:


### PR DESCRIPTION
In the absence of a deployed image (which would _probably_ be more ideal?), this
alternative eliminates the requirement to clone the repo as well as makes the base image and Git reference configurable if users wanted to use UBI9 instead of Fedora, for instance.
